### PR TITLE
Add Markdown editor with ChatGPT sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # codex
+
 Test av OpenAI Codex
+
+## Webbasert markdown-editor
+
+Denne katalogen inneholder en enkel Flask-applikasjon som starter en webbasert
+markdown-editor med en sidepanel som bruker ChatGPT via OpenAI sitt API. For å
+kjøre serveren må du ha `OPENAI_API_KEY` satt i miljøet.
+
+```
+cd web_editor
+pip install flask openai
+python server.py
+```
+
+Applikasjonen blir da tilgjengelig på `http://localhost:5000`.

--- a/web_editor/server.py
+++ b/web_editor/server.py
@@ -1,0 +1,42 @@
+import os
+from flask import Flask, request, jsonify, send_from_directory
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = Flask(__name__, static_folder="static", static_url_path="/static")
+
+@app.route("/")
+def index():
+    return send_from_directory(app.static_folder, "index.html")
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    data = request.get_json(force=True)
+    messages = data.get("messages", [])
+    markdown = data.get("markdown", "")
+
+    system_message = {
+        "role": "system",
+        "content": (
+            "Du er en hjelpsom assistent som redigerer markdown-tekst. "
+            "Svar kun med den oppdaterte markdownen."
+        ),
+    }
+    prompt_messages = [system_message] + messages
+    prompt_messages.append({"role": "user", "content": f"Gjeldende tekst:\n{markdown}"})
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=prompt_messages,
+        )
+        new_markdown = response.choices[0].message["content"].strip()
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify({"markdown": new_markdown})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/web_editor/static/index.html
+++ b/web_editor/static/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Markdown Editor med ChatGPT</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div id="container">
+    <div id="editor">
+        <textarea id="markdown" placeholder="Skriv markdown her..."></textarea>
+    </div>
+    <div id="sidebar">
+        <div id="messages"></div>
+        <form id="chat-form">
+            <input id="chat-input" type="text" placeholder="Skriv melding..." autocomplete="off">
+            <button type="submit">Send</button>
+        </form>
+    </div>
+</div>
+<script src="/static/script.js"></script>
+</body>
+</html>

--- a/web_editor/static/script.js
+++ b/web_editor/static/script.js
@@ -1,0 +1,43 @@
+async function sendMessage(content) {
+    const textarea = document.getElementById('markdown');
+    const markdown = textarea.value;
+
+    const messages = window.chatHistory || [];
+    messages.push({ role: 'user', content });
+
+    const response = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages, markdown })
+    });
+
+    const data = await response.json();
+    if (data.markdown) {
+        textarea.value = data.markdown;
+        addMessage('assistant', data.markdown);
+    } else if (data.error) {
+        addMessage('assistant', 'Feil: ' + data.error);
+    }
+
+    window.chatHistory = messages;
+}
+
+function addMessage(role, text) {
+    const messagesDiv = document.getElementById('messages');
+    const div = document.createElement('div');
+    div.className = role;
+    div.textContent = text;
+    messagesDiv.appendChild(div);
+    messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+document.getElementById('chat-form').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const input = document.getElementById('chat-input');
+    const text = input.value.trim();
+    if (text) {
+        addMessage('user', text);
+        sendMessage(text);
+        input.value = '';
+    }
+});

--- a/web_editor/static/style.css
+++ b/web_editor/static/style.css
@@ -1,0 +1,52 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    height: 100vh;
+}
+
+#container {
+    display: flex;
+    width: 100%;
+}
+
+#editor {
+    flex: 2;
+    padding: 10px;
+}
+
+#sidebar {
+    flex: 1;
+    border-left: 1px solid #ccc;
+    display: flex;
+    flex-direction: column;
+}
+
+#markdown {
+    width: 100%;
+    height: 100%;
+    resize: none;
+}
+
+#messages {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+    background: #f3f3f3;
+}
+
+#chat-form {
+    display: flex;
+    border-top: 1px solid #ccc;
+}
+
+#chat-input {
+    flex: 1;
+    padding: 10px;
+    border: none;
+}
+
+#chat-form button {
+    padding: 10px 15px;
+}


### PR DESCRIPTION
## Summary
- add a small Flask app with ChatGPT integration
- document how to run the app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68890ea98884832ea6fdde34275c0f28